### PR TITLE
version 1.1.0: BREAKING CHANGE: WGApiWoTBlitzTankopedia.update()

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ reportInvalidStringEscapeSequence = false
 
 
 [tool.pytest.ini_options]
-minversion = "7.0"
+minversion = "7.4"
 addopts = "-v --cov=src"
 filterwarnings = [
     'ignore:Inheritance class ThrottledClientSession from ClientSession is discouraged:DeprecationWarning',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,7 @@ reportInvalidStringEscapeSequence = false
 [tool.pytest.ini_options]
 minversion = "7.4"
 addopts = "-v --cov=src"
+pythonpath = "src" # avoid import path append in test files
 filterwarnings = [
     'ignore:Inheritance class ThrottledClientSession from ClientSession is discouraged:DeprecationWarning',
     'ignore:legacy JSON format is depreciated:DeprecationWarning',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "blitz-models"
-version = "1.0.6"
+version = "1.1.0"
 authors = [{ name = "Jylpah", email = "jylpah@gmail.com" }]
 description = "Pydantic models for Wargaming's World of Tanks Blitz game "
 readme = "README.md"

--- a/src/blitzmodels/account.py
+++ b/src/blitzmodels/account.py
@@ -157,7 +157,7 @@ class Account(JSONExportable, CSVExportable, TXTExportable, TXTImportable, Impor
             error(f"{err}")
         return None
 
-    def update(self, update: "AccountInfo") -> bool:
+    def update_info(self, update: "AccountInfo") -> bool:
         """Update Account() from WGACcountInfo i.e. from WG API"""
         updated: bool = False
         try:

--- a/src/blitzmodels/map.py
+++ b/src/blitzmodels/map.py
@@ -149,7 +149,7 @@ class Maps(RootModel, JSONExportable):
                 raise ValueError("map name and key given, but key is not a string")
         self.root[map.key] = map
 
-    def update(self, new: "Maps") -> Tuple[set[str], set[str]]:
+    def update_maps(self, new: "Maps") -> Tuple[set[str], set[str]]:
         """update Maps with another Maps instance"""
         # self.__root__.update(new.__root__)
 
@@ -157,7 +157,12 @@ class Maps(RootModel, JSONExportable):
         old_keys: set[str] = {map.key for map in self}
         added: set[str] = new_keys - old_keys
         updated: set[str] = new_keys & old_keys
-        updated = {key for key in updated if new[key] != self[key]}
 
-        self.root.update({(key, new[key]) for key in added | updated})
+        self.root.update({(key, new[key]) for key in added})
+
+        updated = {key for key in updated if new[key] != self[key]}
+        updated_ids: set[str] = set()
+        for key in updated:
+            if self[key].update(new[key]):
+                updated_ids.add(key)
         return (added, updated)

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -1,15 +1,11 @@
-import sys
 import pytest  # type: ignore
 from os.path import basename
 from pathlib import Path
 import logging
-
 from pyutils import awrap
 from pydantic_exportables import export
 
-sys.path.insert(0, str(Path(__file__).parent.parent.resolve() / "src"))
-
-from blitzmodels import Account  # noqa: E402
+from blitzmodels import Account
 
 logger = logging.getLogger()
 error = logger.error

--- a/tests/test_map.py
+++ b/tests/test_map.py
@@ -1,18 +1,14 @@
-import sys
 import pytest  # type: ignore
 from pathlib import Path
 from typing import Tuple
 import logging
+from blitzmodels import Maps, MapMode, MapModeStr
 
 logger = logging.getLogger()
 error = logger.error
 message = logger.warning
 verbose = logger.info
 debug = logger.debug
-
-sys.path.insert(0, str(Path(__file__).parent.parent.resolve() / "src"))
-
-from blitzmodels import Maps, MapMode, MapModeStr  # noqa: E402
 
 
 ########################################################
@@ -121,8 +117,8 @@ async def test_2_update(
         added
     ), f"could not import all maps: got {len(added)}, expected {maps_added_updated[0]}"
 
-    assert (
-        maps_added_updated[1] == len(updated)
+    assert maps_added_updated[1] == len(
+        updated
     ), f"could not import all maps: got {len(updated)}, expected {maps_added_updated[0]}"
 
 

--- a/tests/test_map.py
+++ b/tests/test_map.py
@@ -111,7 +111,7 @@ async def test_2_update(
         maps_new := await Maps.open_json(maps_new_fn)
     ) is not None, f"could not open maps from: {maps_new_fn.name}"
 
-    (added, updated) = maps_old.update(maps_new)
+    (added, updated) = maps_old.update_maps(maps_new)
 
     assert maps_added_updated[0] == len(
         added

--- a/tests/test_region.py
+++ b/tests/test_region.py
@@ -1,11 +1,6 @@
-import sys
 import pytest  # type: ignore
-from pathlib import Path
 from typing import List
-
-sys.path.insert(0, str(Path(__file__).parent.parent.resolve() / "src"))
-
-from blitzmodels import Region  # noqa: E402
+from blitzmodels import Region
 
 
 ########################################################

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -1,4 +1,3 @@
-import sys
 import pytest  # type: ignore
 from os.path import basename
 from pathlib import Path
@@ -6,16 +5,13 @@ import logging
 
 from pyutils import awrap
 from pydantic_exportables import export
+from blitzmodels import Release
 
 logger = logging.getLogger()
 error = logger.error
 message = logger.warning
 verbose = logger.info
 debug = logger.debug
-
-sys.path.insert(0, str((Path(__file__).parent.parent / "src").resolve()))
-
-from blitzmodels import Release  # noqa: E402
 
 
 ########################################################

--- a/tests/test_replay.py
+++ b/tests/test_replay.py
@@ -1,17 +1,7 @@
-import sys
 import pytest  # type: ignore
 from pathlib import Path
 from random import choice
 import logging
-
-logger = logging.getLogger()
-error = logger.error
-message = logger.warning
-verbose = logger.info
-debug = logger.debug
-
-sys.path.insert(0, str(Path(__file__).parent.parent.resolve() / "src"))
-
 from blitzmodels import (  # noqa: E402
     WGApiWoTBlitzTankopedia,
     Maps,
@@ -22,6 +12,12 @@ from blitzmodels.wotinspector.wi_apiv1 import (  # noqa: E402
     ReplayFile,
     WoTinspector,
 )
+
+logger = logging.getLogger()
+error = logger.error
+message = logger.warning
+verbose = logger.info
+debug = logger.debug
 
 ########################################################
 #
@@ -148,8 +144,8 @@ async def test_1_import_export_replays(datafiles: Path, tmp_path: Path) -> None:
 
         allied_platoons, enemy_platoons = replay.get_platoons()
         # this "should" always match in public games
-        assert (
-            len(allied_platoons) == len(enemy_platoons)
+        assert len(allied_platoons) == len(
+            enemy_platoons
         ), f"number of platoons does not match: allied={len(allied_platoons)}, enemy={len(enemy_platoons)}"
 
         if len(allied_platoons) > 0:
@@ -351,8 +347,8 @@ async def test_4_post_replay(
                 fetch_json=fetch_json,
             )
             assert replay_id is not None, f"could not post a replay: {replay_fn.name}"
-            assert (
-                not fetch_json or isinstance(replay_json, ReplayJSON)
+            assert not fetch_json or isinstance(
+                replay_json, ReplayJSON
             ), f"did not receive ReplayJSON: type={type(replay_json)}, replay_json={replay_json}"
             if (max_replays := max_replays - 1) <= 0:
                 break

--- a/tests/test_tank.py
+++ b/tests/test_tank.py
@@ -1,4 +1,3 @@
-import sys
 import pytest  # type: ignore
 from os.path import basename
 from pathlib import Path
@@ -8,23 +7,20 @@ from random import shuffle
 from typing import List
 import logging
 
-logger = logging.getLogger()
-error = logger.error
-message = logger.warning
-verbose = logger.info
-debug = logger.debug
-
-sys.path.insert(0, str(Path(__file__).parent.parent.resolve() / "src"))
-
-from blitzmodels import (  # noqa: E402
+from blitzmodels import (
     Tank,
     EnumNation,
     EnumVehicleTier,
     EnumVehicleTypeInt,
     EnumVehicleTypeStr,
 )
-from blitzmodels import WGApiWoTBlitzTankopedia  # noqa: E402
+from blitzmodels import WGApiWoTBlitzTankopedia
 
+logger = logging.getLogger()
+error = logger.error
+message = logger.warning
+verbose = logger.info
+debug = logger.debug
 
 ########################################################
 #
@@ -300,7 +296,9 @@ async def test_11_WGApiTankopedia(
                     await file.read()
                 )
             except Exception:
-                assert False, f"Parsing test file WGApiWoTBlitzTankopedia() failed: {basename(tankopedia_fn)}"
+                assert (
+                    False
+                ), f"Parsing test file WGApiWoTBlitzTankopedia() failed: {basename(tankopedia_fn)}"
 
     debug("read %d tanks", len(tankopedia.data))
     assert tankopedia.meta is not None, "Failed to update meta"
@@ -311,7 +309,9 @@ async def test_11_WGApiTankopedia(
         len(tankopedia.data) == tankopedia_tanks
     ), f"could not import all the tanks: got {tankopedia.data}, should be {tankopedia_tanks}"
 
-    assert tankopedia.has_codes, f"could not generate all the codes: tanks={len(tankopedia.data)}, codes={len(tankopedia.codes)}"
+    assert (
+        tankopedia.has_codes
+    ), f"could not generate all the codes: tanks={len(tankopedia.data)}, codes={len(tankopedia.codes)}"
     # test tankopedia export import
     tankopedia_file: str = f"{tmp_path.resolve()}/tankopedia.json"
     try:
@@ -347,7 +347,9 @@ async def test_12_WGApiTankopedia_sorted(
                     await file.read()
                 )
             except Exception:
-                assert False, f"Parsing test file WGApiWoTBlitzTankopedia() failed: {basename(tankopedia_fn)}"
+                assert (
+                    False
+                ), f"Parsing test file WGApiWoTBlitzTankopedia() failed: {basename(tankopedia_fn)}"
 
     debug("read %d tanks", len(tankopedia.data))
     tanks: list[Tank] = list()

--- a/tests/test_wgapi.py
+++ b/tests/test_wgapi.py
@@ -1,20 +1,10 @@
-import sys
 import pytest  # type: ignore
 from pathlib import Path
 import logging
 import json
 
-logger = logging.getLogger()
-error = logger.error
-message = logger.warning
-verbose = logger.info
-debug = logger.debug
-
-sys.path.insert(0, str(Path(__file__).parent.parent.resolve() / "src"))
-
-from blitzmodels import Account, Region, WGApi  # noqa: E402
-from blitzmodels import (  # noqa: E402
-    AccountInfo,
+from blitzmodels import Account, Region, WGApi, AccountInfo
+from blitzmodels import (
     PlayerAchievementsMaxSeries,
     TankStat,
     WGApiWoTBlitzTankopedia,
@@ -22,6 +12,11 @@ from blitzmodels import (  # noqa: E402
     WGApiTankString,
 )
 
+logger = logging.getLogger()
+error = logger.error
+message = logger.warning
+verbose = logger.info
+debug = logger.debug
 
 ########################################################
 #
@@ -257,7 +252,9 @@ def test_5_player_achievements_example_instance() -> None:
     try:
         _ = PlayerAchievementsMaxSeries.example_instance()
     except Exception as err:
-        assert False, f"Could not validate PlayerAchievementsMaxSeries example instance: {type(err)}: {err}"
+        assert (
+            False
+        ), f"Could not validate PlayerAchievementsMaxSeries example instance: {type(err)}: {err}"
 
 
 @pytest.mark.asyncio
@@ -274,8 +271,10 @@ async def test_6_api_tankopedia(
             assert len(tankopedia) > 0, "API returned empty tankopedia"
 
         assert (
-            (tankopedia := await wg.get_tankopedia()) is not None
-        ), "could not fetch tankopedia from WG API from (default server = eu)"
+            tankopedia := await wg.get_tankopedia()
+        ) is not None, (
+            "could not fetch tankopedia from WG API from (default server = eu)"
+        )
         for tank_id in tanks_remove:
             tankopedia.pop(tank_id)
 
@@ -288,11 +287,11 @@ async def test_6_api_tankopedia(
 
         (added, updated) = tankopedia.update(tankopedia_new)
 
-        assert (
-            len(added) == len(tanks_remove)
+        assert len(added) == len(
+            tanks_remove
         ), f"incorrect number of added tanks reported {len(added) } != {len(tanks_remove)}"
-        assert (
-            len(updated) == len(tanks_updated)
+        assert len(updated) == len(
+            tanks_updated
         ), f"incorrect number of updated tanks reported {len(updated) } != {len(tanks_updated)}"
 
 
@@ -314,7 +313,9 @@ async def test_7_api_tankstrs(
                 False
             ), f"failed to parse test file as WGApiTankString(): {fn.name}: {err}"
         if (tank := Tank.transform(tank_str)) is None:
-            assert False, f"could not transform WGApiTankString() to Tank(): {tank_str.user_string}"
+            assert (
+                False
+            ), f"could not transform WGApiTankString() to Tank(): {tank_str.user_string}"
 
     async with WGApi() as wg:
         for user_str in wgapi_tankstrs_user_strings:

--- a/tests/test_wgapi.py
+++ b/tests/test_wgapi.py
@@ -285,7 +285,7 @@ async def test_6_api_tankopedia(
         for wgtank in tanks_updated:
             tankopedia_new.add(wgtank)
 
-        (added, updated) = tankopedia.update(tankopedia_new)
+        (added, updated) = tankopedia.update_tanks(tankopedia_new)
 
         assert len(added) == len(
             tanks_remove

--- a/tests/test_wi_api_v2.py
+++ b/tests/test_wi_api_v2.py
@@ -1,4 +1,3 @@
-import sys
 import pytest  # type: ignore
 import pytest_asyncio
 from pathlib import Path
@@ -6,22 +5,20 @@ import logging
 from typing import Dict, List, Any
 from configparser import ConfigParser
 
-logger = logging.getLogger()
-error = logger.error
-message = logger.warning
-verbose = logger.info
-debug = logger.debug
-
-sys.path.insert(0, str(Path(__file__).parent.parent.resolve() / "src"))
-
-from blitzmodels.wotinspector.wi_apiv2 import (  # noqa: E402
+from blitzmodels.wotinspector.wi_apiv2 import (
     Replay,
     PlayerData,
     ReplaySummary,
     WoTinspector,
 )
 
-from blitzmodels import get_config_file, WGApiWoTBlitzTankopedia, Maps  # noqa: E402
+from blitzmodels import get_config_file, WGApiWoTBlitzTankopedia, Maps
+
+logger = logging.getLogger()
+error = logger.error
+message = logger.warning
+verbose = logger.info
+debug = logger.debug
 
 
 ########################################################


### PR DESCRIPTION
- `WGApiWoTBlitzTankopedia.update()` renamed to `WGApiWoTBlitzTankopedia.update_tanks()` due to generic `JSONExportable.update()`