### PR TITLE
version 1.2.15: add Windows-friendly config file option

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "blitz-models"
-version = "1.2.14"
+version = "1.2.15"
 authors = [{ name = "Jylpah", email = "jylpah@gmail.com" }]
 description = "Pydantic models for Wargaming's World of Tanks Blitz game "
 readme = "README.md"

--- a/src/blitzmodels/config.py
+++ b/src/blitzmodels/config.py
@@ -7,6 +7,7 @@ CONFIG_FILES: list[Path] = [
     Path(__file__).parent / CONFIG_FILE,
     Path.home() / f".{CONFIG_FILE}",
     Path.home() / ".config" / CONFIG_FILE,
+    Path.home() / ".config/wotblitz.ini",
     Path.home() / ".config/blitzstats/config",
     Path.home() / ".config/blitz-stats/config",
     Path.home() / ".config/blitz-replays/config",


### PR DESCRIPTION
- For Windows use: `%USERPROFILE%\.config\wotblitz.ini`